### PR TITLE
fix(submodule): update a-d-b url to AgentDisruptBench

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/Kavirubc/SELAR.git
 [submodule "projects/a-d-b"]
 	path = projects/a-d-b
-	url = https://github.com/Kavirubc/a-d-b.git
+	url = https://github.com/Kavirubc/AgentDisruptBench.git


### PR DESCRIPTION
## Problem
The cron job workflow **Update Submodule Pointers** has been failing on every scheduled run because the submodule `projects/a-d-b` references a repository URL (`https://github.com/Kavirubc/a-d-b.git`) that no longer exists — it was renamed to `AgentDisruptBench`.

```
fatal: clone of 'https://github.com/Kavirubc/a-d-b.git' into submodule path failed
```

## Fix
Updated `.gitmodules` to point `projects/a-d-b` at the correct URL:
```
https://github.com/Kavirubc/AgentDisruptBench.git
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration for a project dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->